### PR TITLE
Sevdesk CSV import: add new options and deprecate account creation with old API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,9 @@ ignore = [
   "PD901", #  Avoid using the generic variable name `df` for DataFrames"
 
   # gives falls positives and isn't hard to check munually
-  "ERA001"
+  "ERA001",
+
+  "RET505" # superfluous-else-return
 ]
 
 [tool.mypy]

--- a/sevdesk-invoicer/sevdesk_wise_importer/__init__.py
+++ b/sevdesk-invoicer/sevdesk_wise_importer/__init__.py
@@ -161,9 +161,17 @@ def import_record(
     neutral_currencies: list[NeutralTransactionCurrencies],
     dry_run: bool = False,
 ) -> None:
-    if record["Status"] == "REFUNDED":
+    status = record["Status"]
+    if status == "REFUNDED":
         print(f"Skipping refunded transaction {record['ID']}")
         return
+    elif status == "CANCELLED":
+        print(f"Skipping cancelled transaction {record['ID']}")
+        return
+    elif status == "COMPLETED":
+        pass
+    else:
+        die(f"Unknown status '{status}'")
     direction = record["Direction"]
     if direction == "IN":
         currency = record["Target currency"]

--- a/sevdesk-invoicer/sevdesk_wise_importer/__init__.py
+++ b/sevdesk-invoicer/sevdesk_wise_importer/__init__.py
@@ -10,9 +10,9 @@ import json
 import os
 import sys
 from contextlib import ExitStack
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, NoReturn
-from dataclasses import dataclass
 
 from sevdesk import Client
 from sevdesk.client.api.check_account import create_check_account, get_check_accounts
@@ -42,10 +42,12 @@ def die(msg: str) -> NoReturn:
     print(msg, file=sys.stderr)
     sys.exit(1)
 
+
 @dataclass
 class NeutralTransactionCurrencies:
     source_currency: str
     target_currency: str
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
@@ -82,7 +84,7 @@ def parse_args() -> argparse.Namespace:
         "--ignore-currency",
         action="append",
         default=[],
-        help="Ignore any transaction involving this currency."
+        help="Ignore any transaction involving this currency.",
     )
     parser.add_argument(
         "--dry-run",
@@ -123,7 +125,9 @@ class Accounts:
                     and obj.type != CheckAccountResponseModelType.REGISTER
                 ):
                     return obj.id
-        die(f"missing account '{name}', please create the respective account on sevdesk by uploading a dummy CSV")
+        die(
+            f"missing account '{name}', please create the respective account on sevdesk by uploading a dummy CSV"
+        )
         # account = CheckAccountModel(
         #     name=name,
         #     type=CheckAccountModelType.ONLINE,
@@ -185,11 +189,15 @@ def import_record(
         source_fee = float(source_fee_str) if source_fee_str else 0.0
         amount = -float(record["Source amount (after fees)"]) - source_fee
     elif direction == "NEUTRAL":
-        currencies = NeutralTransactionCurrencies(record["Source currency"], record["Target currency"])
+        currencies = NeutralTransactionCurrencies(
+            record["Source currency"], record["Target currency"]
+        )
         currency = currencies.target_currency
         exchange_rate = record["Exchange rate"]
         if currencies not in neutral_currencies:
-            print(f"Skipping neutral transaction with currencies {currencies.source_currency} -> {currencies.target_currency}")
+            print(
+                f"Skipping neutral transaction with currencies {currencies.source_currency} -> {currencies.target_currency}"
+            )
             return
         payee_payer_name = record["Source name"]
         amount = float(record["Target amount (after fees)"])
@@ -198,7 +206,9 @@ def import_record(
 
     # Wise exports a list of transaction involving all accounts
     if currency in ignore_currencies and direction in {"IN", "OUT"}:
-        print(f"Skipping {direction} transaction {record['ID']} with ignored currency {currency}")
+        print(
+            f"Skipping {direction} transaction {record['ID']} with ignored currency {currency}"
+        )
         return
 
     reference = record["Reference"]
@@ -252,7 +262,10 @@ def import_record(
 def main() -> None:
     args = parse_args()
     ignore_currencies = set(args.ignore_currency)
-    neutral_currencies = [NeutralTransactionCurrencies(source_currency, target_currency) for source_currency, target_currency in args.import_neutral]
+    neutral_currencies = [
+        NeutralTransactionCurrencies(source_currency, target_currency)
+        for source_currency, target_currency in args.import_neutral
+    ]
     if len(args.add_account) == 0:
         die("No accounts specifed, use --add-account")
     with ExitStack() as exit_stack:
@@ -281,7 +294,13 @@ def main() -> None:
 
         for record in records:
             import_record(
-                client, accounts, record, imported_transactions, ignore_currencies, neutral_currencies, dry_run=args.dry_run
+                client,
+                accounts,
+                record,
+                imported_transactions,
+                ignore_currencies,
+                neutral_currencies,
+                dry_run=args.dry_run,
             )
             if not args.dry_run:
                 args.import_state_file.write_text(

--- a/sevdesk-invoicer/sevdesk_wise_importer/__init__.py
+++ b/sevdesk-invoicer/sevdesk_wise_importer/__init__.py
@@ -123,26 +123,27 @@ class Accounts:
                     and obj.type != CheckAccountResponseModelType.REGISTER
                 ):
                     return obj.id
-        account = CheckAccountModel(
-            name=name,
-            type=CheckAccountModelType.ONLINE,
-            currency=currency,
-            status=CheckAccountModelStatus.VALUE_100,
-            id=UNSET,
-            object_name=UNSET,
-            create=UNSET,
-            update=UNSET,
-            sev_client=UNSET,
-            import_type=CheckAccountModelImportType.CSV,
-            bank_server=UNSET,
-            auto_map_transactions=1,
-        )
+        die(f"missing account '{name}', please create the respective account on sevdesk by uploading a dummy CSV")
+        # account = CheckAccountModel(
+        #     name=name,
+        #     type=CheckAccountModelType.ONLINE,
+        #     currency=currency,
+        #     status=CheckAccountModelStatus.VALUE_100,
+        #     id=UNSET,
+        #     object_name=UNSET,
+        #     create=UNSET,
+        #     update=UNSET,
+        #     sev_client=UNSET,
+        #     import_type=CheckAccountModelImportType.CSV,
+        #     bank_server=UNSET,
+        #     auto_map_transactions=1,
+        # )
 
-        res = create_check_account.sync(client=self.client, json_body=account)
-        if res is None or res.objects is Unset:
-            die(f"Failed to create account {name}")
-        self.cache[currency] = res.objects.id
-        return res.objects.id
+        # res = create_check_account.sync(client=self.client, json_body=account)
+        # if res is None or res.objects is Unset:
+        #     die(f"Failed to create account {name}")
+        # self.cache[currency] = res.objects.id
+        # return res.objects.id
 
 
 # These had to be introduced when switching from the wise API to the CSV export


### PR DESCRIPTION
Sevdesk removed the old API to create accounts as explained in this [issue](https://github.com/numtide/freelancer-toolbox/issues/88) and the new API endpoints do not allow creating accounts with a currency other than EUR.

Therefore, a new sevdesk account can only be used to track transactions that results in EUR, like currency exchanges. On Wise, these are neutral transactions. This pull request adds the option to upload neutral transactions to Wise EUR account on sevdesk. Additionally, another option is introduced that allows for ignoring USD transactions, as no respective USD account can be created on sevdesk.

The account creation was deprecated in the script. Currently, a user has to create an account manually on the website once, with the respective name and account number, as requested by the script. To do so, a dummy CSV or STA file has to be uploaded that includes one parseable transaction. Afterwards, the dummy transaction can be deleted. This function also exists in the new sevdesk API and could be automated in the future. A dummy CSV can look like this:

```xml
ID,Direction,"Finished on","Source fee currency","Name","Betrag","Waehrung",Reference
TRANSFER-1234567890,IN,"2025-04-16",EUR,"Somebody",10.00,EUR,123456789012345
```

Cancelled transactions are now skipped and the script exits when an unknown status is encountered.